### PR TITLE
Support for Plone's new Collection type

### DIFF
--- a/collective/carousel/browser/viewlets.py
+++ b/collective/carousel/browser/viewlets.py
@@ -35,7 +35,9 @@ class CarouselViewlet(ViewletBase):
             
             # It doesn't make sense to show *all* objects from a collection 
             # - some of them might return hundreeds of objects
-            return provider.queryCatalog()[:7]
+            #TODO: why 7 then?? Doesn't make much sense. And it breaks with the new Collection type. 
+            #return provider.queryCatalog()[:7]
+            return provider.queryCatalog()
         return results
 
     def canSeeEditLink(self, provider):

--- a/collective/carousel/schemaextender.py
+++ b/collective/carousel/schemaextender.py
@@ -33,7 +33,7 @@ class ContentTypeExtender(object):
             # the field accepts Collections only atm.
             # Would be cool to have ATRBW to be able to select items by
             # interface with something like 'allowed_interfaces'
-            allowed_types = ('Topic'),
+            allowed_types = ('Topic', 'Collection'),
             relationship = 'Carousel',
             languageIndependent = True,
             multiValued = True,

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,7 @@ Changelog
 
 1.5 - Unreleased
 ----------------
+- Added support to Plone's new Collection type. [davidjonas]
 
 - Don't base the carousel portlet on the collection one since it brings quite
   some unnecessary fileds that don't make sense in this context.


### PR DESCRIPTION
Hi! 
I've made slight changes to adapt to the Collection type while keeping all the support for the Topic type. Not much changes actually. Just added the type to the allowed types and removed the hard slice on 7 items that causes an attribute error on the new type. This limit of 7 items is also too low imho. There are many cases where users will want more than that and the behaviour is not clear or explained anywhere. It is a cleaner fail when a user adds a collection with too many items and easily understands why the slideshow does not look good than if they add a collection with 10 items and the slideshow shows only 7 for no apparent reason.

The proper way to impose a limit on the number of items would be to add one more configuration to the carousel and then limit the query to it. 
