### PR TITLE
Added description for dexterity support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Changelog
   javascript and CSS.
   [thet]
 
+- Added description for dexterity support
+  [bogdangi]
+
 
 1.6.2 - August 28, 2013
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -127,4 +127,12 @@ Developed by **Jarn AS** |---| http://www.jarn.com
 Development sponsored by the **Bergen Public Library** |---|
 http://www.nettbiblioteket.no
 
+Dexterity
+=========
+
+`collective.carouselbehaviour`_ provides Dexterity-based (``plone.app.dexterity``) content types support.
+
+  .. |---| unicode:: U+2014  .. em dash
+  .. _collective.carouselbehaviour: http://pypi.python.org/pypi/collective.carouselbevaviour
+
 


### PR DESCRIPTION
Hi,

Could you please merge it if you find it useful?
I try to find the possibility add carousel for my Dexterity content types but I couldn't find any ways.
Now it more easy just switch on behaviour.

Best regards,
Bogdan.
