### PR TITLE
Namespace tweak to prevent clashes with other systems that use the .carousel class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.7dev - (unreleased)
 ---------------------
 
+- Edited the css/html/js so that carousel uses the .collective.carousel
+  selector. Fixes this issue: 
+  https://github.com/collective/collective.carousel/issues/13
+  [pigeonflight]
+
 - Play/Autoscroll the carousel again, when the mouse leaves the carousel.
   [thet]
 

--- a/collective/carousel/browser/resources/carousel.css
+++ b/collective/carousel/browser/resources/carousel.css
@@ -2,7 +2,7 @@
 
 /* root element for the scrollable.
  * when scrolling occurs this element stays still. */
-.carousel {
+.collective.carousel {
 	position: relative;
 	z-index: 0;
     padding: 0;
@@ -49,7 +49,7 @@ div.scrollable div.items div.itemPadding {
 }
 
 /* To make images sit within the carousel's boundaries no matter what */
-.carousel img {
+.collective.carousel img {
     max-width: 100%;
 }
 
@@ -57,7 +57,7 @@ div.scrollable div.items div.itemPadding {
 /* NAVIGATION BUTTONS */
 
 /* prev, next, prevPage and nextPage buttons */
-.carousel:hover a.browse {
+.collective.carousel:hover a.browse {
     display: block;
 }
 a.browse {
@@ -179,7 +179,7 @@ div.toolBar {
 .portletCarouselWrapper {
 	border: none;
 }
-.portletCarouselWrapper .carousel {
+.portletCarouselWrapper .collective.carousel {
     width: 100%;
     padding: 0;
     margin-bottom: 0;

--- a/collective/carousel/browser/resources/carousel.js
+++ b/collective/carousel/browser/resources/carousel.js
@@ -127,7 +127,7 @@
 
     $(document).ready(function() {
         $('html').addClass('hideTools');
-        $('.carousel').initializeCarousel();
+        $('.collective.carousel').initializeCarousel();
     });
 
 })(jQuery);

--- a/collective/carousel/browser/templates/carousel.pt
+++ b/collective/carousel/browser/templates/carousel.pt
@@ -4,7 +4,7 @@
 
      <tal:carousel repeat="provider view/getProviders">
         <div class="carousel"
-             tal:attributes="class python:repeat['provider'].end and 'carousel lastCarousel' or 'carousel'"
+             tal:attributes="class python:repeat['provider'].end and 'collective carousel lastCarousel' or 'collective carousel'"
              tal:condition="python: view.results(provider)">
 
             <div class="toolBar" tal:condition="python:view.canSeeEditLink(provider)">


### PR DESCRIPTION
This is a tweak to collective.carousel which previously would conflict with other systems that used the .carousel class such as twitter bootstrap's carousel.
